### PR TITLE
pre-populate QT_PLUGIN_PATH from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,43 @@ set_target_properties(
              OUTPUT_NAME "graph_viewer"
              LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pyhpp_plot")
 
+# pyhpp_plot_graph_viewer is a python module that spawn Qt windows. for this, at
+# runtime, it need a QT_PLUGIN_PATH env var with a path where the shared lib for
+# the current Qt "platform" are. Here we find a QT_PLUGIN_PATH that would work
+# at config time, so that at runtime we can append that as a default fallback,
+# if a end user has Qt installed in a non-FHS standard place and did not
+# manually tune their $QT_PLUGIN_PATH env var for it
+
+set(QT_PLUGIN_PATH_CMAKE)
+
+# First, we might need to manually discover platforms plugins which are not
+# installed in the same prefix as Qt5Gui. eg. Wayland.
+find_package(
+  Qt5 CONFIG
+  COMPONENTS WaylandClient
+  QUIET)
+if(Qt5WaylandClient_FOUND)
+  cmake_path(GET Qt5WaylandClient_DIR PARENT_PATH _p)
+  file(GLOB pluginTargets "${_p}/Qt5Gui/Qt5Gui_*.cmake")
+  if(pluginTargets)
+    foreach(pluginTarget ${pluginTargets})
+      include(${pluginTarget})
+    endforeach()
+  endif()
+endif()
+
+foreach(p IN LISTS Qt5Gui_PLUGINS)
+  get_target_property(_l ${p} IMPORTED_LOCATION_RELEASE)
+  cmake_path(GET _l PARENT_PATH _pp)
+  cmake_path(GET _pp PARENT_PATH _ppp)
+  if(NOT _ppp IN_LIST QT_PLUGIN_PATH_CMAKE)
+    set(QT_PLUGIN_PATH_CMAKE ${QT_PLUGIN_PATH_CMAKE} ${_ppp})
+  endif()
+endforeach()
+
+add_compile_definitions(
+  "QT_PLUGIN_PATH_CMAKE=\"$<JOIN:${QT_PLUGIN_PATH_CMAKE},:>\"")
+
 install(TARGETS pyhpp_plot_graph_viewer
         DESTINATION "${PYTHON_SITELIB}/pyhpp_plot")
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,8 @@
           packages = {
             default = self'.packages.hpp-plot;
             hpp-plot = pkgs.python3Packages.hpp-plot.overrideAttrs (super: {
-              buildInputs = super.buildInputs ++ [
-                pkgs.libsForQt5.qtwayland
-              ];
+              buildInputs =
+                super.buildInputs ++ lib.optional (pkgs.stdenv.hostPlatform.isLinux) pkgs.libsForQt5.qtwayland;
               src = lib.fileset.toSource {
                 root = ./.;
                 fileset = lib.fileset.unions [

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,10 @@
         {
           packages = {
             default = self'.packages.hpp-plot;
-            hpp-plot = pkgs.python3Packages.hpp-plot.overrideAttrs {
+            hpp-plot = pkgs.python3Packages.hpp-plot.overrideAttrs (super: {
+              buildInputs = super.buildInputs ++ [
+                pkgs.libsForQt5.qtwayland
+              ];
               src = lib.fileset.toSource {
                 root = ./.;
                 fileset = lib.fileset.unions [
@@ -39,7 +42,7 @@
                   ./src
                 ];
               };
-            };
+            });
           };
         };
     };

--- a/src/pyhpp_plot/graph_viewer.cc
+++ b/src/pyhpp_plot/graph_viewer.cc
@@ -237,6 +237,17 @@ void showInteractiveGraph(bp::object py_graph, bp::object node_callback,
 }  // namespace
 
 BOOST_PYTHON_MODULE(graph_viewer) {
+  // Append what was found at build time to QT_PLUGIN_PATH
+  // so users dont need to set it, even if their platform plugin
+  // is in non-standard place. They can still define the env
+  // var to override this behavior.
+  auto plugin_paths = qgetenv("QT_PLUGIN_PATH");
+  if (!plugin_paths.isEmpty()) {
+    plugin_paths.append(":");
+  }
+  plugin_paths.append(QT_PLUGIN_PATH_CMAKE);
+  qputenv("QT_PLUGIN_PATH", plugin_paths);
+
   // Expose MenuActionProxy for adding menu actions from Python
   bp::class_<MenuActionProxy, boost::noncopyable>("MenuActionProxy",
                                                   bp::no_init)


### PR DESCRIPTION
Fix eg. `qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""` when a user with a working Qt "platform" plugin for their current WM/DE is not in a standard location but easy to find at config time.

They still could set `QT_PLUGIN_PATH` env var for that, but here we append what was found at config time, so they don't need to do it anymore, but they can still overwrite that in a transparent and standard way.