### PR TITLE
npm: fallback tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,19 +271,44 @@ install(
 
 # appWeb
 if(USE_JS)
-    find_program(NPM_EXECUTABLE npm REQUIRED)
+    find_program(NPM_EXECUTABLE npm)
 
-    set(REACT_APP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/web_app)
-    set(REACT_DIST_DIR ${REACT_APP_DIR}/dist)
+    if(NPM_EXECUTABLE)
+        set(REACT_APP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/web_app)
+        set(REACT_DIST_DIR ${REACT_APP_DIR}/dist)
 
-    add_custom_target(
-        web_app_hpp_plot_build
-        ALL
-        COMMAND ${NPM_EXECUTABLE} install
-        COMMAND ${NPM_EXECUTABLE} run build
-        WORKING_DIRECTORY ${REACT_APP_DIR}
-        COMMENT "Building React app"
-    )
-
-    install(DIRECTORY "${REACT_DIST_DIR}/" DESTINATION "share/hpp-plot/webapp")
+        # TODO: build that is build dir and not src
+        add_custom_target(
+            web_app_hpp_plot_build
+            ALL
+            COMMAND ${NPM_EXECUTABLE} install
+            COMMAND ${NPM_EXECUTABLE} run build
+            WORKING_DIRECTORY ${REACT_APP_DIR}
+            COMMENT "Building React app"
+        )
+        install(
+            DIRECTORY "${REACT_DIST_DIR}/"
+            DESTINATION "share/hpp-plot/webapp"
+        )
+    else()
+        # tar -c --xz -C src/web_app/dist -f webapp.tar.xz .
+        message(
+            WARNING
+            "npm was not found, using prebuild webapp, might not be up-to-date"
+        )
+        include(FetchContent)
+        FetchContent_Declare(
+            webapp
+            URL
+                "https://github.com/humanoid-path-planner/hpp-plot/releases/download/v9.0.0/webapp.tar.xz"
+            URL_HASH
+                "SHA256=deb49dbb5d3f1b9f725f424f99de878cb6ffdb3f289c57dc5a14838afaef33c0"
+            DOWNLOAD_EXTRACT_TIMESTAMP ON
+        )
+        FetchContent_MakeAvailable(webapp)
+        install(
+            DIRECTORY "${webapp_SOURCE_DIR}/"
+            DESTINATION "share/hpp-plot/webapp"
+        )
+    endif()
 endif()

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             npmDeps = pkgs-final.fetchNpmDeps {
               name = "${drv-final.pname}-${drv-final.version}-npm-deps";
               src = drv-final.src + "/src/web_app/";
-              hash = "sha256-B8s+hhTn7CG3q8bx490SM8fKFAEGOmHX7u8JN/7qI94=";
+              hash = "sha256-GAYdugZFMygk0MXyXxf2wSsWRvn/aW4YeFH2v62IZjI=";
             };
             preBuild = ''
               cd ../src/web_app

--- a/src/web_app/package-lock.json
+++ b/src/web_app/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "cytoscape-hpp-plot",
-  "version": "0.1.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cytoscape-hpp-plot",
-      "version": "0.1.0",
+      "version": "9.0.0",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "cytoscape": "^3.30.3",
         "react": "^18.3.1",

--- a/src/web_app/package.json
+++ b/src/web_app/package.json
@@ -1,7 +1,8 @@
 {
   "name": "cytoscape-hpp-plot",
-  "private": true,
-  "version": "0.1.0",
+  "version": "9.0.0",
+  "description": "Plotting tools for HPP with cytoscape",
+  "license": "BSD-2-Clause",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
if npm is not available (eg. in manylinux env for PyPI builds), we can publish a tarball and use that one.
for now this is a very manual `tar -c --xz -C src/web_app/dist -f webapp.tar.xz .`